### PR TITLE
string -> std::string

### DIFF
--- a/microcr/src/image.cpp
+++ b/microcr/src/image.cpp
@@ -75,7 +75,7 @@ Image* Image::cloneEmpty() {
   return cloned;
 }
 
-Image* Image::loadImage(string filePath) {
+Image* Image::loadImage(std::string filePath) {
   IplImage* loaded = cvLoadImage(filePath.c_str(),
                                  CV_LOAD_IMAGE_GRAYSCALE);
 

--- a/microcr/src/image.h
+++ b/microcr/src/image.h
@@ -10,7 +10,7 @@ class Image
 
  public:
 
-  static Image* loadImage(string filename);
+  static Image* loadImage(std::string filename);
 
   Image(IplImage* p_img);
   ~Image();


### PR DESCRIPTION
This was needed to compile. I also had to change the following in the Makefile for it to build on linux:

```
#LIBS = -L/usr/local/lib -ltesseract_api `pkg-config --libs opencv`
LIBS = -L/usr/local/lib -ltesseract `pkg-config --libs opencv`
#DYLIB = -arch x86_64 -dynamiclib -o libmicrocr.dylib
DYLIB = -dynamiclib -o libmicrocr.so
#INSTALL_PATH = -install_name /usr/local/lib/microcr/libmicrocr.dylib
INSTALL_PATH = 
```

I've totally forgotten how to write Makefiles, so I just left it at that
